### PR TITLE
LF-14476: Prefix update and color generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,127 @@ livefyre-theme-styler
 =====================
 
 Sets namespaced CSS styles for a given Appkit Component
+
+## Theme styler
+Provides ability to apply themes to the DOM for a specific text CSS string. This is also instance specific based on the provided prefix attribute.
+
+The CSS file that you wish to be themed will look almost exactly like a regular CSS file. Instead of values for the variables, you will use this format:
+`var(--varName)`. The `varName` string is the name of the attribute in the theme object that will be used to replace this string.
+
+A full example of a rule is:
+```css
+.testSelector {
+    background: var(--testBackground);
+    color: var(--testColor);
+}
+```
+When calling `applyTheme`, the theme object passed in will then have:
+```
+{
+    testBackground: '#f00',
+    testColor: '#00f'
+}
+```
+Those replacements will be made and the resulting style will be:
+```css
+.testSelector {
+    background: #f00;
+    color: #00f;
+}
+```
+
+If one of the attributes is left off, the entire line will be removed:
+```
+{
+    testBackground: '#f00'
+}
+.testSelector {
+    background: #f00;
+}
+```
+
+If there are no remaining items within a rule, the entire rule is removed.
+
+
+Example implementation:
+```javascript
+var ts = new ThemeStyler({
+    css: themableCssString,
+    prefix: '[lf-app-prefix="someuidstring"] '
+});
+ts.applyTheme({});
+```
+
+In the above example, the `themableCssString` variable is a text CSS file. Often created like `require('text!path/to/file.css')`. This is the file that this
+instance of ThemeStyler will each time `applyTheme` is called.
+
+The `prefix` attribute is an instance-specific selector which will be added at
+the beginning of *each* line of CSS in the `themableCssString` file. A simple
+example is:
+```
+themableCssString = '.testSelector {}'
+prefix = '[lf-app-prefix="someuidstring"] '
+// Run through applyTheme
+'[lf-app-prefix="someuidstring"] .testSelector {}'
+```
+
+If you wish to have the prefix be the root selector for your themable CSS, then
+you would make `:host` be the selector for your CSS rules, like this:
+```
+themableCssString = ':host {}'
+```
+
+Once the theme is applied, you would end up with this:
+```
+'[lf-app-prefix="someuidstring"] {}'
+```
+
+Also, if you want to use multiple selectors at the top level, you could do this:
+```
+themableCssString = ':host.testSelector {}'
+prefix = '[lf-app-prefix="someuidstring"]'
+// Run through applyTheme
+'[lf-app-prefix="someuidstring"].testSelector {}'
+```
+
+Notice that the prefix does not have a trailing space. The :host replacement
+removes a single space in front of it, so any selectors that are attached to the
+:host selectors will be automatically attached to the prefix.
+
+
+## Color generator
+A simple generator for colors. This takes a config object along with the prefix
+you'd like to add to the styles and the root color.
+
+Here is a good example:
+```
+generateColors('linkAttachment', backgroundColor, {
+    light: {
+        backgroundColor: {fn: 'darken', amt: 5},
+        borderColor: {color: 'rgba(0,0,0,0.3)'},
+        textColor: {color: '#000', fn: 'lighten', amt: 40}
+    },
+    dark: {
+        backgroundColor: {fn: 'lighten', amt: 5},
+        borderColor: {color: 'rgba(0,0,0,0.5)'},
+        textColor: {color: '#fff', fn: 'darken', amt: 40}
+    }
+})
+```
+
+The generator will determine whether the `backgroundColor` argument is light or
+dark and use the appropriate config object (if provided). If light/dark is not
+provided, the object must contain attribute: color object config pairs.
+
+Color object config attributes:
+- `color`: The color to use for the root. By itself, this will be the final color.
+when used in conjunction with `fn`, this value will be modified.
+- `fn`: The color function to apply to the color. If no color is specified, the
+`backgroundColor` value is used.
+- `amt`: The amount to adjust the color. This must be used in conjunction with the
+`fn` attribute.
+
+Function config options:
+- `blacken`: Blacken the color by `amt`.
+- `darken`: Darken the color by `amt`.
+- `lighten`: Lighten the color by `amt`.

--- a/bower.json
+++ b/bower.json
@@ -1,12 +1,12 @@
 {
   "name": "livefyre-theme-styler",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "main": [
     "./src/main.js"
   ],
   "dependencies": {
     "cajon": "git://github.com/requirejs/cajon.git#~0.1.12",
-    "lodash": "2.4.1",
+    "mout": "0.11.0",
     "requirejs": "~2.1.5",
     "requirejs-text": "~2.0.5",
     "tinycolor": "~1.0.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "livefyre-theme-styler",
   "description": "Set namespaced CSS styles for a given Appkit Component",
   "author": "Livefyre <support@livefyre.com>",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "devDependencies": {
     "bower": "1.3.8",
     "jshint": "~1.1.0",

--- a/requirejs.conf.js
+++ b/requirejs.conf.js
@@ -2,6 +2,7 @@ require.config({
   baseUrl: '/',
   paths: {
     chai: 'lib/chai/chai',
+    mout: 'lib/mout/src',
     sinon: 'lib/sinonjs/sinon',
     'sinon-chai': 'lib/sinon-chai/lib/sinon-chai',
     text: 'lib/requirejs-text/text',
@@ -13,6 +14,14 @@ require.config({
   }, {
     name: 'livefyre-theme-styler',
     location: 'src'
+  }, {
+    name: 'livefyre-theme-styler/colors',
+    location: 'src',
+    main: 'colors'
+  }, {
+    name: 'livefyre-theme-styler/utils',
+    location: 'src',
+    main: 'utils'
   }],
   shim: {
     sinon: {

--- a/src/colors.js
+++ b/src/colors.js
@@ -1,0 +1,75 @@
+'use strict';
+
+var camelCase = require('mout/string/camelCase');
+var forOwn = require('mout/object/forOwn');
+var has = require('mout/object/has');
+var tinycolor = require('tinycolor');
+
+var Colors = {};
+
+/**
+ * Blacken the provided color by the provided amount.
+ * @param {string} color Color to blacken.
+ * @param {number} amt Amount to blacken the color.
+ * @return {string} The new hex value of the color.
+ */
+Colors.blacken = function(color, amt) {
+  return tinycolor.mix(color, '#000', amt).toHexString();
+};
+
+/**
+ * Darken the provided color by the provided amount.
+ * @param {string} color Color to darken.
+ * @param {number} amt Amount to darken the color.
+ * @return {string} The new hex value of the color.
+ */
+Colors.darken = function(color, amt) {
+  return tinycolor(color).darken(amt).toString();
+};
+
+/**
+ * Use the provided opts as a config for generating colors based on the provided
+ * base color argument. With the config, all keys will get prefixed with the
+ * provided prefix argument.
+ * @param {string} prefix The prefix to add onto the property names.
+ * @param {string} color The base color to use when generating.
+ * @param {Object} opts The color configuration options.
+ * @return {Object} Object containing generated colors.
+ */
+Colors.generateColors = function(prefix, color, opts) {
+  var hasThemes = has(opts, 'light') || has(opts, 'dark');
+  var isLight = tinycolor(color).isLight();
+  var theme = hasThemes ? (isLight ? opts.light : opts.dark) : opts;
+  var _opts = {};
+
+  forOwn(theme, function(prop, key) {
+    var activeColor;
+    var attrName = camelCase([prefix, key].join('-'));
+
+    if (!prop) {
+      _opts[attrName] = color;
+      return;
+    }
+    activeColor = prop.color ? prop.color : color;
+
+    if (!prop.fn) {
+      _opts[attrName] = activeColor;
+      return;
+    }
+    _opts[attrName] = Colors[prop.fn](activeColor, prop.amt);
+  });
+
+  return _opts;
+};
+
+/**
+ * Lighten the provided color by the provided amount.
+ * @param {string} color Color to lighten.
+ * @param {number} amt Amount to lighten the color.
+ * @return {string} The new hex value of the color.
+ */
+Colors.lighten = function(color, amt) {
+  return tinycolor(color).lighten(amt).toString();
+};
+
+module.exports = Colors;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var _ = require('lodash');
-var tinycolor = require('tinycolor');
+var merge = require('mout/object/merge');
+var ColorGenerator = require('./colors');
 
 function getBackgroundColorFromThemeOpts(themeOpts) {
   themeOpts = themeOpts || {};
@@ -9,35 +9,39 @@ function getBackgroundColorFromThemeOpts(themeOpts) {
 }
 
 function interpolateButtonStyles(themeOpts) {
-  var buttonThemeOpts = {};
   var backgroundColor = getBackgroundColorFromThemeOpts(themeOpts);
-  if (backgroundColor.isLight()) {
-    buttonThemeOpts.buttonTextColor = tinycolor('#000').lighten(40).toHexString();
-    buttonThemeOpts.buttonHoverBackgroundColor = backgroundColor.darken(5).toHexString();
-    buttonThemeOpts.buttonActiveBackgroundColor = backgroundColor.darken(15).toHexString();
-    buttonThemeOpts.buttonBorderColor = 'rgba(0,0,0,0.3)';
-  } else if (backgroundColor.isDark()) {
-    buttonThemeOpts.buttonTextColor = tinycolor('#FFF').darken(40).toHexString();
-    buttonThemeOpts.buttonHoverBackgroundColor = backgroundColor.lighten(5).toHexString();
-    buttonThemeOpts.buttonActiveBackgroundColor = backgroundColor.lighten(15).toHexString();
-    buttonThemeOpts.buttonBorderColor = 'rgba(0,0,0,0.5)';
-  }
-  return _.extend(buttonThemeOpts, themeOpts);
+  var buttonThemeOpts = ColorGenerator.generateColors('button', backgroundColor, {
+    light: {
+      activeBackgroundColor: {fn: 'darken', amt: 15},
+      borderColor: {color: 'rgba(0,0,0,0.3)'},
+      hoverBackgroundColor: {fn: 'darken', amt: 5},
+      textColor: {color: '#000', fn: 'lighten', amt: 40}
+    },
+    dark: {
+      activeBackgroundColor: {fn: 'lighten', amt: 15},
+      borderColor: {color: 'rgba(0,0,0,0.5)'},
+      hoverBackgroundColor: {fn: 'lighten', amt: 5},
+      textColor: {color: '#fff', fn: 'darken', amt: 40}
+    }
+  });
+  return merge(buttonThemeOpts, themeOpts);
 }
 
 function interpolateLinkAttachmentStyles(themeOpts) {
-  var linkThemeOpts = {};
   var backgroundColor = getBackgroundColorFromThemeOpts(themeOpts);
-  if (backgroundColor.isLight()) {
-    linkThemeOpts.linkAttachmentTextColor = tinycolor('#000').lighten(40).toHexString();
-    linkThemeOpts.linkAttachmentBackgroundColor = backgroundColor.darken(5).toHexString();
-    linkThemeOpts.linkAttachmentBorderColor = 'rgba(0,0,0,0.3)';
-  } else if (backgroundColor.isDark()) {
-    linkThemeOpts.linkAttachmentTextColor = tinycolor('#FFF').darken(40).toHexString();
-    linkThemeOpts.linkAttachmentBackgroundColor = backgroundColor.lighten(5).toHexString();
-    linkThemeOpts.linkAttachmentBorderColor = 'rgba(0,0,0,0.5)';
-  }
-  return _.extend(linkThemeOpts, themeOpts);
+  var linkThemeOpts = ColorGenerator.generateColors('linkAttachment', backgroundColor, {
+    light: {
+      backgroundColor: {fn: 'darken', amt: 5},
+      borderColor: {color: 'rgba(0,0,0,0.3)'},
+      textColor: {color: '#000', fn: 'lighten', amt: 40}
+    },
+    dark: {
+      backgroundColor: {fn: 'lighten', amt: 5},
+      borderColor: {color: 'rgba(0,0,0,0.5)'},
+      textColor: {color: '#fff', fn: 'darken', amt: 40}
+    }
+  });
+  return merge(linkThemeOpts, themeOpts);
 }
 
 module.exports = {


### PR DESCRIPTION
https://livefyre.atlassian.net/browse/LF-14476

1. :host selector in themable css. This is a placeholder so that the prefix that is added to each line in the css is now the full selector for the rule. The host string is removed and now will support targeting immediate elements.
2. Added color generation. Takes a root color and does color modifications to attributes specified in the color config object argument.